### PR TITLE
Avoid duplicate symbol publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
           fi
 
           for package in "${packages[@]}"; do
-            dotnet nuget push "$package" -k ${{ steps.nuget_login.outputs.NUGET_API_KEY }} -s "$NUGET_SOURCE" --skip-duplicate
+            dotnet nuget push "$package" -k ${{ steps.nuget_login.outputs.NUGET_API_KEY }} -s "$NUGET_SOURCE" --skip-duplicate --no-symbols
           done
 
           for symbol in "${symbols[@]}"; do


### PR DESCRIPTION
## Summary

Fixes the NuGet release workflow so package publishing does not upload symbol packages twice.

`dotnet nuget push` can automatically push a matching `.snupkg` when pushing a `.nupkg` from the same directory. The workflow also had a second explicit symbol upload loop, so symbol packages could be submitted twice.

## Change

- Adds `--no-symbols` to the `.nupkg` push loop.
- Keeps the explicit `.snupkg` loop so symbols are still published once.

## Validation

- `dotnet build --no-restore --configuration Release /p:GeneratePackageOnBuild=false`
- `dotnet test --no-build --configuration Release --verbosity minimal`