### PR TITLE
Add raw event store support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added `IRawEventStore` and `RawEventData` for appending raw JSON events without CLR event types.
   - Added raw append support to the in-memory and EF Core event stores.
   - Added dependency injection registration and tests for centralized raw event store scenarios.
+  - Added a centralized raw event store sample using SQLite.
 
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ### Added
+
+  - Added `IRawEventStore` and `RawEventData` for appending raw JSON events without CLR event types.
+  - Added raw append support to the in-memory and EF Core event stores.
+  - Added dependency injection registration and tests for centralized raw event store scenarios.
+
 ------
 
 ## [v1.0.0] - 2026-07-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+------
+
+## [v1.1.0] - 2026-08-06
+
 - ### Added
 
   - Added `IRawEventStore` and `RawEventData` for appending raw JSON events without CLR event types.

--- a/Krackend.sln
+++ b/Krackend.sln
@@ -39,6 +39,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Krackend.EventSourcing.Anal
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Krackend.EventSourcing.Testing", "src\Krackend.EventSourcing.Testing\Krackend.EventSourcing.Testing.csproj", "{363783F6-B512-4228-A413-F81027349471}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Krackend.EventSourcing.Centralized.Sample", "samples\Krackend.EventSourcing.Centralized.Sample\Krackend.EventSourcing.Centralized.Sample.csproj", "{CB23D773-B534-467C-9A71-983CD3759FB9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -193,6 +195,18 @@ Global
 		{363783F6-B512-4228-A413-F81027349471}.Release|x64.Build.0 = Release|Any CPU
 		{363783F6-B512-4228-A413-F81027349471}.Release|x86.ActiveCfg = Release|Any CPU
 		{363783F6-B512-4228-A413-F81027349471}.Release|x86.Build.0 = Release|Any CPU
+		{CB23D773-B534-467C-9A71-983CD3759FB9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CB23D773-B534-467C-9A71-983CD3759FB9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CB23D773-B534-467C-9A71-983CD3759FB9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CB23D773-B534-467C-9A71-983CD3759FB9}.Debug|x64.Build.0 = Debug|Any CPU
+		{CB23D773-B534-467C-9A71-983CD3759FB9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CB23D773-B534-467C-9A71-983CD3759FB9}.Debug|x86.Build.0 = Debug|Any CPU
+		{CB23D773-B534-467C-9A71-983CD3759FB9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CB23D773-B534-467C-9A71-983CD3759FB9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CB23D773-B534-467C-9A71-983CD3759FB9}.Release|x64.ActiveCfg = Release|Any CPU
+		{CB23D773-B534-467C-9A71-983CD3759FB9}.Release|x64.Build.0 = Release|Any CPU
+		{CB23D773-B534-467C-9A71-983CD3759FB9}.Release|x86.ActiveCfg = Release|Any CPU
+		{CB23D773-B534-467C-9A71-983CD3759FB9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -210,6 +224,7 @@ Global
 		{A034C0CA-07B0-43E0-9D63-F8B3A25EC73A} = {6711B2C7-0746-4A45-8E61-BA235480C06A}
 		{6AB71B0E-2DCE-4C96-A0A5-FE1B7BE72717} = {6711B2C7-0746-4A45-8E61-BA235480C06A}
 		{363783F6-B512-4228-A413-F81027349471} = {6711B2C7-0746-4A45-8E61-BA235480C06A}
+		{CB23D773-B534-467C-9A71-983CD3759FB9} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3F2B5274-3B0F-4F73-B211-9BD128E1AF56}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ dotnet add package Krackend.EventSourcing.Abstractions
 - state rehydration with reducers
 - snapshots of state
 - EF Core event store adapter
+- raw JSON event appends for centralized event stores
 - runtime diagnostics
 - Roslyn analyzers
 - testing helpers
@@ -60,6 +61,24 @@ public sealed record RenameCustomer(string CustomerId, string Name)
 }
 
 await customerService.ExecuteAsync(new RenameCustomer("customer-001", "New Name"));
+```
+
+Centralized raw event store usage:
+
+```csharp
+var rawEventStore = provider.GetRequiredService<IRawEventStore>();
+
+await rawEventStore.AppendRawAsync(
+    streamName: "integration-events",
+    streamId: "customers:customer-001",
+    expectedVersion: ExpectedVersion.Any,
+    events:
+    [
+        new RawEventData(
+            "Customers.CustomerRenamed",
+            "1.0.0",
+            "{\"customerId\":\"customer-001\",\"name\":\"New Name\"}")
+    ]);
 ```
 
 See [docs/event-sourcing.md](docs/event-sourcing.md) for the full guide.

--- a/README.md
+++ b/README.md
@@ -82,3 +82,9 @@ await rawEventStore.AppendRawAsync(
 ```
 
 See [docs/event-sourcing.md](docs/event-sourcing.md) for the full guide.
+
+Samples:
+
+- `samples/Krackend.EventSourcing.Sqlite.Sample`: typed event-sourced write model with SQLite.
+- `samples/Krackend.EventSourcing.Centralized.Sample`: centralized raw JSON event store with SQLite.
+- `samples/Krackend.EventSourcing.Pelican.Sample`: exploratory Pelican/template integration.

--- a/docs/event-sourcing.md
+++ b/docs/event-sourcing.md
@@ -390,6 +390,66 @@ Guidance:
 - `NoStream`: first event must create the stream.
 - `Any`: append without optimistic version check, useful when the caller intentionally does not own stream concurrency.
 
+## Appending Raw Events
+
+Use `IRawEventStore` when the service stores events produced by other bounded contexts and should not reference every CLR event type from the whole system.
+
+This is useful for centralized event stores, audit logs, forwarding services, and integration collectors. The raw API stores the same envelope shape as typed event sourcing, but it does not use event schemas from attributes, reducers, state rehydration, or snapshots.
+
+```csharp
+var rawEventStore = provider.GetRequiredService<IRawEventStore>();
+
+await rawEventStore.AppendRawAsync(
+    streamName: "integration-events",
+    streamId: "customers:customer-001",
+    expectedVersion: ExpectedVersion.Any,
+    events:
+    [
+        new RawEventData(
+            eventType: "Customers.CustomerRenamed",
+            eventSchemaVersion: "1.0.0",
+            payload: """
+            {"customerId":"customer-001","name":"New Name"}
+            """,
+            metadata: """
+            {"producer":"customers-api","messageId":"9ff3b801"}
+            """)
+    ],
+    cancellationToken);
+```
+
+Raw events still receive envelope fields from the current `IEventExecutionContext`:
+
+- `CorrelationId`
+- `CausationId`
+- `UserId`
+- `TenantId`
+- `Source`
+- `OccurredAt`
+- `StreamVersion`
+- `GlobalPosition`
+
+If `RawEventData.Metadata` is provided, it is stored as-is. If it is omitted, configured envelope metadata providers are collected and serialized into `Metadata`.
+
+Read raw events with the same bounded APIs:
+
+```csharp
+var page = await rawEventStore.ReadStreamAsync(
+    streamName: "integration-events",
+    streamId: "customers:customer-001",
+    fromVersion: 1,
+    maxCount: 100,
+    cancellationToken);
+
+var next = await rawEventStore.ReadFromAsync(
+    streamName: "integration-events",
+    afterGlobalPosition: 5000,
+    maxCount: 500,
+    cancellationToken);
+```
+
+Use typed `IEventStore` for bounded-context write models that need reducers and rehydration. Use `IRawEventStore` for centralized storage where JSON is the contract and C# event classes would become operational debt.
+
 ## Reading Events
 
 There is no unbounded stream-load API.

--- a/docs/event-sourcing.md
+++ b/docs/event-sourcing.md
@@ -818,4 +818,5 @@ Console.WriteLine(result.CurrentState.Name);
 The repository contains:
 
 - `samples/Krackend.EventSourcing.Sqlite.Sample`: compact event-sourced application service flow with SQLite.
+- `samples/Krackend.EventSourcing.Centralized.Sample`: centralized raw JSON event store flow with SQLite.
 - `samples/Krackend.EventSourcing.Pelican.Sample`: exploratory Pelican/template integration sample. The integration pieces are intentionally outside the core event sourcing runtime.

--- a/docs/raw-event-store-roadmap.md
+++ b/docs/raw-event-store-roadmap.md
@@ -1,0 +1,79 @@
+# Raw Event Store Roadmap
+
+## Goal
+
+Add an untyped event store API for centralized event logs that receive events from many bounded contexts without requiring CLR event classes for every event name and schema version.
+
+The existing typed event sourcing API remains unchanged. Bounded contexts can continue using typed events, reducers, snapshots, and state rehydration. The raw API is additive and targets centralized storage, auditing, forwarding, and integration scenarios.
+
+## Design Principles
+
+- Keep typed event sourcing as the primary write-model API for bounded contexts.
+- Do not require centralized event stores to reference every bounded-context event assembly.
+- Store raw JSON payloads using the same envelope/table shape as typed events.
+- Preserve optimistic concurrency through `ExpectedVersion`.
+- Preserve existing envelope metadata: stream, version, global position, correlation, causation, tenant, user, source, and metadata.
+- Do not deserialize raw payloads into CLR event types in the central store path.
+- Keep reducer/state/snapshot behavior out of the raw API.
+- Allow future validation through JSON Schema or another schema catalog without making it mandatory.
+
+## Proposed API
+
+Add `RawEventData`:
+
+```csharp
+public sealed record RawEventData(
+    string EventType,
+    SemanticVersion EventSchemaVersion,
+    string Payload,
+    string? Metadata = null);
+```
+
+Add `IRawEventStore`:
+
+```csharp
+public interface IRawEventStore
+{
+    Task<IReadOnlyCollection<EventEnvelope>> AppendRawAsync(
+        string streamName,
+        string streamId,
+        ExpectedVersion expectedVersion,
+        IReadOnlyCollection<RawEventData> events,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyCollection<EventEnvelope>> ReadStreamAsync(
+        string streamName,
+        string streamId,
+        long fromVersion,
+        int maxCount,
+        CancellationToken cancellationToken = default);
+
+    Task<long> GetCurrentVersionAsync(
+        string streamName,
+        string streamId,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyCollection<EventEnvelope>> ReadFromAsync(
+        string streamName,
+        long afterGlobalPosition,
+        int maxCount,
+        CancellationToken cancellationToken = default);
+}
+```
+
+## Implementation Steps
+
+1. Add raw contracts to `Krackend.EventSourcing.Abstractions`.
+2. Add raw envelope creation support in the core runtime.
+3. Implement `IRawEventStore` in `InMemoryEventStore`.
+4. Implement `IRawEventStore` in `EntityFrameworkEventStore<TDbContext>`.
+5. Register `IRawEventStore` in core and EF dependency injection.
+6. Add tests for raw append/read, metadata preservation, expected versions, and coexistence with typed events.
+7. Update documentation with centralized event store guidance and examples.
+
+## Future Work
+
+- Optional JSON Schema validation per `EventType + EventSchemaVersion`.
+- Optional raw event ingestion endpoint helpers.
+- Optional event forwarding/subscription helpers over `IEventLogReader`/`IRawEventStore`.
+- Optional package for central event store operational tooling.

--- a/docs/raw-event-store-roadmap.md
+++ b/docs/raw-event-store-roadmap.md
@@ -63,13 +63,13 @@ public interface IRawEventStore
 
 ## Implementation Steps
 
-1. Add raw contracts to `Krackend.EventSourcing.Abstractions`.
-2. Add raw envelope creation support in the core runtime.
-3. Implement `IRawEventStore` in `InMemoryEventStore`.
-4. Implement `IRawEventStore` in `EntityFrameworkEventStore<TDbContext>`.
-5. Register `IRawEventStore` in core and EF dependency injection.
-6. Add tests for raw append/read, metadata preservation, expected versions, and coexistence with typed events.
-7. Update documentation with centralized event store guidance and examples.
+1. Done: add raw contracts to `Krackend.EventSourcing.Abstractions`.
+2. Done: add raw envelope creation support in the core runtime.
+3. Done: implement `IRawEventStore` in `InMemoryEventStore`.
+4. Done: implement `IRawEventStore` in `EntityFrameworkEventStore<TDbContext>`.
+5. Done: register `IRawEventStore` in core and EF dependency injection.
+6. Done: add tests for raw append/read, metadata preservation, expected versions, and coexistence with typed events.
+7. Done: update documentation with centralized event store guidance and examples.
 
 ## Future Work
 

--- a/samples/Krackend.EventSourcing.Centralized.Sample/Data/CentralEventStoreDbContext.cs
+++ b/samples/Krackend.EventSourcing.Centralized.Sample/Data/CentralEventStoreDbContext.cs
@@ -1,0 +1,11 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Krackend.EventSourcing.Centralized.Sample.Data;
+
+public sealed class CentralEventStoreDbContext : DbContext
+{
+    public CentralEventStoreDbContext(DbContextOptions<CentralEventStoreDbContext> options)
+        : base(options)
+    {
+    }
+}

--- a/samples/Krackend.EventSourcing.Centralized.Sample/Ingestion/CentralEventIngestionService.cs
+++ b/samples/Krackend.EventSourcing.Centralized.Sample/Ingestion/CentralEventIngestionService.cs
@@ -1,0 +1,42 @@
+using Krackend.EventSourcing.Centralized.Sample.Requests;
+using Krackend.EventSourcing.Envelopes;
+using Krackend.EventSourcing.Stores;
+
+namespace Krackend.EventSourcing.Centralized.Sample.Ingestion;
+
+public sealed class CentralEventIngestionService
+{
+    private const string CentralStreamName = "integration-events";
+
+    private readonly IRawEventStore _eventStore;
+
+    public CentralEventIngestionService(IRawEventStore eventStore)
+    {
+        _eventStore = eventStore;
+    }
+
+    public Task<IReadOnlyCollection<EventEnvelope>> AppendAsync(
+        IncomingIntegrationEvent request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var streamId = $"{request.BoundedContext}:{request.AggregateType}:{request.AggregateId}";
+        var expectedVersion = request.ExpectedStreamVersion is null
+            ? ExpectedVersion.Any
+            : ExpectedVersion.Exact(request.ExpectedStreamVersion.Value);
+
+        return _eventStore.AppendRawAsync(
+            CentralStreamName,
+            streamId,
+            expectedVersion,
+            [
+                new RawEventData(
+                    request.EventType,
+                    request.EventSchemaVersion,
+                    request.Payload,
+                    request.Metadata)
+            ],
+            cancellationToken);
+    }
+}

--- a/samples/Krackend.EventSourcing.Centralized.Sample/Krackend.EventSourcing.Centralized.Sample.csproj
+++ b/samples/Krackend.EventSourcing.Centralized.Sample/Krackend.EventSourcing.Centralized.Sample.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.7" />
+    <ProjectReference Include="..\..\src\Krackend.EventSourcing.Abstractions\Krackend.EventSourcing.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Krackend.EventSourcing.EntityFrameworkCore\Krackend.EventSourcing.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\..\src\Krackend.EventSourcing\Krackend.EventSourcing.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Krackend.EventSourcing.Centralized.Sample/Program.cs
+++ b/samples/Krackend.EventSourcing.Centralized.Sample/Program.cs
@@ -1,0 +1,124 @@
+using Krackend.EventSourcing.Centralized.Sample.Data;
+using Krackend.EventSourcing.Centralized.Sample.Ingestion;
+using Krackend.EventSourcing.Centralized.Sample.Requests;
+using Krackend.EventSourcing.Centralized.Sample.Runtime;
+using Krackend.EventSourcing.Contracts;
+using Krackend.EventSourcing.DependencyInjection;
+using Krackend.EventSourcing.Metadata;
+using Krackend.EventSourcing.Stores;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+var databasePath = Path.Combine(AppContext.BaseDirectory, "central-event-store-sample.db");
+
+if (File.Exists(databasePath))
+    File.Delete(databasePath);
+
+var services = new ServiceCollection();
+
+services.AddScoped<SampleExecutionContext>();
+services.AddEventExecutionContext(provider =>
+    provider.GetRequiredService<SampleExecutionContext>());
+
+services.AddDbContext<CentralEventStoreDbContext>(options =>
+    options.UseSqlite($"Data Source={databasePath}"));
+
+services.AddKrackendEventSourcing(options =>
+{
+    options.Stores.Add("integration-events", store =>
+    {
+        store.TableName = "IntegrationEvents";
+    });
+
+    options.Envelope.AddMetadata("collector", _ => "central-event-store");
+});
+
+services.AddScoped<CentralEventIngestionService>();
+services.AddKrackendEntityFrameworkEventStore<CentralEventStoreDbContext>();
+
+await using var provider = services.BuildServiceProvider();
+await using var scope = provider.CreateAsyncScope();
+
+var dbContext = scope.ServiceProvider.GetRequiredService<CentralEventStoreDbContext>();
+await dbContext.Database.EnsureCreatedAsync();
+
+var executionContext = scope.ServiceProvider.GetRequiredService<SampleExecutionContext>();
+executionContext.CorrelationId = "http-request-8f70";
+executionContext.CausationId = "message-3b91";
+executionContext.TenantId = "tenant-demo";
+executionContext.Source = "central-ingestion-api";
+
+var ingestion = scope.ServiceProvider.GetRequiredService<CentralEventIngestionService>();
+
+await ingestion.AppendAsync(new IncomingIntegrationEvent(
+    BoundedContext: "customers",
+    AggregateType: "customer",
+    AggregateId: "customer-001",
+    EventType: "Customers.CustomerCreated",
+    EventSchemaVersion: new SemanticVersion(1, 0, 0),
+    Payload: """
+    {"customerId":"customer-001","name":"Ada Lovelace","email":"ada@example.test"}
+    """,
+    Metadata: """
+    {"producer":"customers-api","messageId":"customers-0001"}
+    """,
+    ExpectedStreamVersion: 0));
+
+await ingestion.AppendAsync(new IncomingIntegrationEvent(
+    BoundedContext: "customers",
+    AggregateType: "customer",
+    AggregateId: "customer-001",
+    EventType: "Customers.CustomerRenamed",
+    EventSchemaVersion: new SemanticVersion(1, 1, 0),
+    Payload: """
+    {"customerId":"customer-001","firstName":"Ada","lastName":"Byron","displayName":"Ada Byron"}
+    """,
+    Metadata: """
+    {"producer":"customers-api","messageId":"customers-0002"}
+    """,
+    ExpectedStreamVersion: 1));
+
+await ingestion.AppendAsync(new IncomingIntegrationEvent(
+    BoundedContext: "payments",
+    AggregateType: "payment",
+    AggregateId: "payment-001",
+    EventType: "Payments.PaymentCaptured",
+    EventSchemaVersion: new SemanticVersion(2, 0, 0),
+    Payload: """
+    {"paymentId":"payment-001","customerId":"customer-001","amount":250.75,"currency":"USD"}
+    """,
+    Metadata: """
+    {"producer":"payments-api","messageId":"payments-0001"}
+    """));
+
+var rawEventStore = scope.ServiceProvider.GetRequiredService<IRawEventStore>();
+
+var customerStream = await rawEventStore.ReadStreamAsync(
+    "integration-events",
+    "customers:customer:customer-001",
+    fromVersion: 1,
+    maxCount: 100);
+
+var globalLog = await rawEventStore.ReadFromAsync(
+    "integration-events",
+    afterGlobalPosition: 0,
+    maxCount: 100);
+
+Console.WriteLine($"Central event store database: {databasePath}");
+Console.WriteLine();
+Console.WriteLine("Customer stream");
+
+foreach (var envelope in customerStream.OrderBy(x => x.StreamVersion))
+{
+    Console.WriteLine($"{envelope.StreamVersion}: {envelope.EventType} schema={envelope.EventSchemaVersion}");
+    Console.WriteLine($"payload={envelope.Payload}");
+}
+
+Console.WriteLine();
+Console.WriteLine("Global log");
+
+foreach (var envelope in globalLog.OrderBy(x => x.GlobalPosition))
+{
+    Console.WriteLine($"{envelope.GlobalPosition}: {envelope.StreamId} / {envelope.EventType}");
+    Console.WriteLine($"correlation={envelope.CorrelationId} causation={envelope.CausationId} tenant={envelope.TenantId}");
+}

--- a/samples/Krackend.EventSourcing.Centralized.Sample/README.md
+++ b/samples/Krackend.EventSourcing.Centralized.Sample/README.md
@@ -1,0 +1,26 @@
+# Centralized Raw Event Store Sample
+
+This sample demonstrates how to build a centralized event store that receives events from multiple bounded contexts without referencing their CLR event classes.
+
+The sample uses:
+
+- `IRawEventStore`
+- `RawEventData`
+- EF Core storage with SQLite
+- one central logical stream named `integration-events`
+- raw JSON payloads and metadata
+- envelope correlation, causation, tenant, source, stream version, and global position
+
+Run it with:
+
+```bash
+dotnet run --framework net9.0 --project samples/Krackend.EventSourcing.Centralized.Sample/Krackend.EventSourcing.Centralized.Sample.csproj
+```
+
+The sample appends:
+
+- `Customers.CustomerCreated` schema `1.0.0`
+- `Customers.CustomerRenamed` schema `1.1.0`
+- `Payments.PaymentCaptured` schema `2.0.0`
+
+The central store does not define any C# event type for those events. It stores the raw JSON payload exactly as received.

--- a/samples/Krackend.EventSourcing.Centralized.Sample/Requests/IncomingIntegrationEvent.cs
+++ b/samples/Krackend.EventSourcing.Centralized.Sample/Requests/IncomingIntegrationEvent.cs
@@ -1,0 +1,13 @@
+using Krackend.EventSourcing.Contracts;
+
+namespace Krackend.EventSourcing.Centralized.Sample.Requests;
+
+public sealed record IncomingIntegrationEvent(
+    string BoundedContext,
+    string AggregateType,
+    string AggregateId,
+    string EventType,
+    SemanticVersion EventSchemaVersion,
+    string Payload,
+    string? Metadata = null,
+    long? ExpectedStreamVersion = null);

--- a/samples/Krackend.EventSourcing.Centralized.Sample/Runtime/SampleExecutionContext.cs
+++ b/samples/Krackend.EventSourcing.Centralized.Sample/Runtime/SampleExecutionContext.cs
@@ -1,0 +1,16 @@
+using Krackend.EventSourcing.Metadata;
+
+namespace Krackend.EventSourcing.Centralized.Sample.Runtime;
+
+public sealed class SampleExecutionContext : IEventExecutionContext
+{
+    public string? CorrelationId { get; set; }
+
+    public string? CausationId { get; set; }
+
+    public string? UserId { get; set; }
+
+    public string? TenantId { get; set; }
+
+    public string? Source { get; set; }
+}

--- a/src/Krackend.EventSourcing.Abstractions/Envelopes/IEventEnvelopeFactory.cs
+++ b/src/Krackend.EventSourcing.Abstractions/Envelopes/IEventEnvelopeFactory.cs
@@ -1,5 +1,7 @@
 namespace Krackend.EventSourcing.Envelopes;
 
+using Krackend.EventSourcing.Stores;
+
 /// <summary>
 /// Creates committed event envelopes from domain events.
 /// </summary>
@@ -14,4 +16,14 @@ public interface IEventEnvelopeFactory
         string? streamType,
         long expectedVersion,
         IReadOnlyCollection<object> events);
+
+    /// <summary>
+    /// Creates envelopes for a raw commit operation.
+    /// </summary>
+    IReadOnlyCollection<EventEnvelope> CreateRaw(
+        string streamName,
+        string streamId,
+        string? streamType,
+        long expectedVersion,
+        IReadOnlyCollection<RawEventData> events);
 }

--- a/src/Krackend.EventSourcing.Abstractions/Stores/IRawEventStore.cs
+++ b/src/Krackend.EventSourcing.Abstractions/Stores/IRawEventStore.cs
@@ -26,6 +26,15 @@ public interface IRawEventStore
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Reads raw events after a global position.
+    /// </summary>
+    Task<IReadOnlyCollection<EventEnvelope>> ReadFromAsync(
+        string streamName,
+        long afterGlobalPosition,
+        int maxCount,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Appends raw events to the stream using optimistic concurrency.
     /// </summary>
     Task<IReadOnlyCollection<EventEnvelope>> AppendRawAsync(

--- a/src/Krackend.EventSourcing.Abstractions/Stores/IRawEventStore.cs
+++ b/src/Krackend.EventSourcing.Abstractions/Stores/IRawEventStore.cs
@@ -1,0 +1,47 @@
+using Krackend.EventSourcing.Envelopes;
+
+namespace Krackend.EventSourcing.Stores;
+
+/// <summary>
+/// Provides append and read operations for events that do not have CLR event types.
+/// </summary>
+public interface IRawEventStore
+{
+    /// <summary>
+    /// Reads committed events for the specified stream from a version range.
+    /// </summary>
+    Task<IReadOnlyCollection<EventEnvelope>> ReadStreamAsync(
+        string streamName,
+        string streamId,
+        long fromVersion,
+        int maxCount,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the current stream version without loading stream events.
+    /// </summary>
+    Task<long> GetCurrentVersionAsync(
+        string streamName,
+        string streamId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Appends raw events to the stream using optimistic concurrency.
+    /// </summary>
+    Task<IReadOnlyCollection<EventEnvelope>> AppendRawAsync(
+        string streamName,
+        string streamId,
+        long expectedVersion,
+        IReadOnlyCollection<RawEventData> events,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Appends raw events to the stream using the specified version precondition.
+    /// </summary>
+    Task<IReadOnlyCollection<EventEnvelope>> AppendRawAsync(
+        string streamName,
+        string streamId,
+        ExpectedVersion expectedVersion,
+        IReadOnlyCollection<RawEventData> events,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Krackend.EventSourcing.Abstractions/Stores/RawEventData.cs
+++ b/src/Krackend.EventSourcing.Abstractions/Stores/RawEventData.cs
@@ -1,0 +1,53 @@
+using Krackend.EventSourcing.Contracts;
+
+namespace Krackend.EventSourcing.Stores;
+
+/// <summary>
+/// Represents an event payload that can be appended without a CLR event type.
+/// </summary>
+public sealed record RawEventData
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RawEventData"/> record.
+    /// </summary>
+    /// <param name="eventType">The logical event type name stored in the envelope.</param>
+    /// <param name="eventSchemaVersion">The event payload schema version.</param>
+    /// <param name="payload">The raw JSON payload to store.</param>
+    /// <param name="metadata">The optional raw JSON metadata to store.</param>
+    public RawEventData(
+        string eventType,
+        SemanticVersion eventSchemaVersion,
+        string payload,
+        string? metadata = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(eventType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(payload);
+
+        EventType = eventType;
+        EventSchemaVersion = eventSchemaVersion == default
+            ? SemanticVersion.Default
+            : eventSchemaVersion;
+        Payload = payload;
+        Metadata = metadata;
+    }
+
+    /// <summary>
+    /// Gets the logical event type name stored in the envelope.
+    /// </summary>
+    public string EventType { get; init; }
+
+    /// <summary>
+    /// Gets the event payload schema version.
+    /// </summary>
+    public SemanticVersion EventSchemaVersion { get; init; }
+
+    /// <summary>
+    /// Gets the raw JSON payload to store.
+    /// </summary>
+    public string Payload { get; init; }
+
+    /// <summary>
+    /// Gets the optional raw JSON metadata to store.
+    /// </summary>
+    public string? Metadata { get; init; }
+}

--- a/src/Krackend.EventSourcing.EntityFrameworkCore/EntityFrameworkEventStore.cs
+++ b/src/Krackend.EventSourcing.EntityFrameworkCore/EntityFrameworkEventStore.cs
@@ -10,7 +10,7 @@ namespace Krackend.EventSourcing.EntityFrameworkCore;
 /// <summary>
 /// Entity Framework Core event store using entities added to the application DbContext model.
 /// </summary>
-public sealed class EntityFrameworkEventStore<TDbContext> : IEventStore, IEventLogReader, IDisposable, IAsyncDisposable
+public sealed class EntityFrameworkEventStore<TDbContext> : IEventStore, IRawEventStore, IEventLogReader, IDisposable, IAsyncDisposable
     where TDbContext : DbContext
 {
     private readonly EventStoreOptionsCollection _stores;
@@ -111,6 +111,34 @@ public sealed class EntityFrameworkEventStore<TDbContext> : IEventStore, IEventL
         return await AppendCoreAsync(streamName, streamId, actualVersion, events, cancellationToken);
     }
 
+    /// <inheritdoc />
+    public async Task<IReadOnlyCollection<EventEnvelope>> AppendRawAsync(
+        string streamName,
+        string streamId,
+        long expectedVersion,
+        IReadOnlyCollection<RawEventData> events,
+        CancellationToken cancellationToken = default)
+        => await AppendRawAsync(streamName, streamId, ExpectedVersion.Exact(expectedVersion), events, cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyCollection<EventEnvelope>> AppendRawAsync(
+        string streamName,
+        string streamId,
+        ExpectedVersion expectedVersion,
+        IReadOnlyCollection<RawEventData> events,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(streamName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(streamId);
+        ArgumentNullException.ThrowIfNull(events);
+
+        var actualVersion = await GetCurrentVersionAsync(streamName, streamId, cancellationToken);
+
+        EnsureExpectedVersion(streamName, streamId, expectedVersion, actualVersion);
+
+        return await AppendRawCoreAsync(streamName, streamId, actualVersion, events, cancellationToken);
+    }
+
     private async Task<IReadOnlyCollection<EventEnvelope>> AppendCoreAsync(
         string streamName,
         string streamId,
@@ -139,6 +167,33 @@ public sealed class EntityFrameworkEventStore<TDbContext> : IEventStore, IEventL
             streamId,
             committedEnvelopes.Count == 0 ? expectedVersion : committedEnvelopes[^1].StreamVersion,
             cancellationToken);
+
+        return committedEnvelopes;
+    }
+
+    private async Task<IReadOnlyCollection<EventEnvelope>> AppendRawCoreAsync(
+        string streamName,
+        string streamId,
+        long expectedVersion,
+        IReadOnlyCollection<RawEventData> events,
+        CancellationToken cancellationToken)
+    {
+        EnsureStore(streamName);
+
+        var set = _dbContext.Set<EventStoreRecord>(streamName);
+        var nextGlobalPosition = await set.MaxAsync(x => (long?)x.GlobalPosition, cancellationToken) ?? 0;
+        var pendingEnvelopes = _envelopeFactory.CreateRaw(streamName, streamId, null, expectedVersion, events);
+        var committedEnvelopes = new List<EventEnvelope>(pendingEnvelopes.Count);
+
+        foreach (var envelope in pendingEnvelopes)
+        {
+            nextGlobalPosition++;
+            var committed = envelope with { GlobalPosition = nextGlobalPosition };
+            set.Add(ToRecord(committed));
+            committedEnvelopes.Add(committed);
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
 
         return committedEnvelopes;
     }

--- a/src/Krackend.EventSourcing.EntityFrameworkCore/EntityFrameworkEventStoreServiceCollectionExtensions.cs
+++ b/src/Krackend.EventSourcing.EntityFrameworkCore/EntityFrameworkEventStoreServiceCollectionExtensions.cs
@@ -24,6 +24,7 @@ public static class EntityFrameworkEventStoreServiceCollectionExtensions
         services.AddScoped<Krackend.EventSourcing.EntityFrameworkCore.EntityFrameworkSnapshotStore<TDbContext>>();
         services.AddScoped<Krackend.EventSourcing.EntityFrameworkCore.EntityFrameworkSnapshotCandidateStore<TDbContext>>();
         services.Replace(ServiceDescriptor.Scoped<IEventStore>(provider => provider.GetRequiredService<Krackend.EventSourcing.EntityFrameworkCore.EntityFrameworkEventStore<TDbContext>>()));
+        services.Replace(ServiceDescriptor.Scoped<IRawEventStore>(provider => provider.GetRequiredService<Krackend.EventSourcing.EntityFrameworkCore.EntityFrameworkEventStore<TDbContext>>()));
         services.Replace(ServiceDescriptor.Scoped<IEventLogReader>(provider => provider.GetRequiredService<Krackend.EventSourcing.EntityFrameworkCore.EntityFrameworkEventStore<TDbContext>>()));
         services.Replace(ServiceDescriptor.Scoped<Krackend.EventSourcing.Snapshots.ISnapshotStore>(provider => provider.GetRequiredService<Krackend.EventSourcing.EntityFrameworkCore.EntityFrameworkSnapshotStore<TDbContext>>()));
         services.Replace(ServiceDescriptor.Scoped<Krackend.EventSourcing.Snapshots.ISnapshotCandidateStore>(provider => provider.GetRequiredService<Krackend.EventSourcing.EntityFrameworkCore.EntityFrameworkSnapshotCandidateStore<TDbContext>>()));

--- a/src/Krackend.EventSourcing/DependencyInjection/EventSourcingServiceCollectionExtensions.cs
+++ b/src/Krackend.EventSourcing/DependencyInjection/EventSourcingServiceCollectionExtensions.cs
@@ -66,6 +66,7 @@ public static class EventSourcingServiceCollectionExtensions
         services.AddScoped<IEventEnvelopeFactory, EventEnvelopeFactory>();
         services.AddScoped<InMemoryEventStore>();
         services.AddScoped<IEventStore>(provider => provider.GetRequiredService<InMemoryEventStore>());
+        services.AddScoped<IRawEventStore>(provider => provider.GetRequiredService<InMemoryEventStore>());
         services.AddScoped<IEventLogReader>(provider => provider.GetRequiredService<InMemoryEventStore>());
         services.AddScoped<IStateRehydrator, StateRehydrator>();
         services.AddScoped(typeof(ICommandStreamResolver<>), typeof(DefaultCommandStreamResolver<>));

--- a/src/Krackend.EventSourcing/Envelopes/EventEnvelopeFactory.cs
+++ b/src/Krackend.EventSourcing/Envelopes/EventEnvelopeFactory.cs
@@ -1,6 +1,7 @@
 using Krackend.EventSourcing.Metadata;
 using Krackend.EventSourcing.Registry;
 using Krackend.EventSourcing.Serialization;
+using Krackend.EventSourcing.Stores;
 
 namespace Krackend.EventSourcing.Envelopes;
 
@@ -71,6 +72,54 @@ public sealed class EventEnvelopeFactory : IEventEnvelopeFactory
                 Source: _executionContext?.Source,
                 Payload: _serializer.Serialize(@event),
                 Metadata: serializedMetadata));
+        }
+
+        return envelopes;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<EventEnvelope> CreateRaw(
+        string streamName,
+        string streamId,
+        string? streamType,
+        long expectedVersion,
+        IReadOnlyCollection<RawEventData> events)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(streamName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(streamId);
+        ArgumentNullException.ThrowIfNull(events);
+
+        var metadata = _metadataCollector.Collect();
+        var serializedMetadata = metadata.Count == 0 ? null : _serializer.Serialize(metadata);
+        var occurredAt = DateTimeOffset.UtcNow;
+        var envelopes = new List<EventEnvelope>(events.Count);
+        var version = expectedVersion;
+
+        foreach (var @event in events)
+        {
+            ArgumentNullException.ThrowIfNull(@event);
+
+            version++;
+
+            envelopes.Add(new EventEnvelope(
+                EventId: Guid.NewGuid(),
+                StreamName: streamName,
+                StreamId: streamId,
+                StreamType: streamType,
+                StreamVersion: version,
+                GlobalPosition: null,
+                EventType: @event.EventType,
+                EventSchemaVersion: @event.EventSchemaVersion,
+                OccurredAt: occurredAt,
+                CorrelationId: _executionContext?.CorrelationId,
+                CausationId: _executionContext?.CausationId,
+                UserId: _executionContext?.UserId,
+                TenantId: _executionContext?.TenantId,
+                Source: _executionContext?.Source,
+                Payload: @event.Payload,
+                Metadata: string.IsNullOrWhiteSpace(@event.Metadata)
+                    ? serializedMetadata
+                    : @event.Metadata));
         }
 
         return envelopes;

--- a/src/Krackend.EventSourcing/Stores/InMemoryEventStore.cs
+++ b/src/Krackend.EventSourcing/Stores/InMemoryEventStore.cs
@@ -6,7 +6,7 @@ namespace Krackend.EventSourcing.Stores;
 /// <summary>
 /// In-memory event store implementation for tests and local development.
 /// </summary>
-public sealed class InMemoryEventStore : IEventStore, IEventLogReader
+public sealed class InMemoryEventStore : IEventStore, IRawEventStore, IEventLogReader
 {
     private readonly IEventEnvelopeFactory _envelopeFactory;
     private readonly ISnapshotCandidateMarker _snapshotCandidateMarker;
@@ -122,6 +122,47 @@ public sealed class InMemoryEventStore : IEventStore, IEventLogReader
     }
 
     /// <inheritdoc />
+    public Task<IReadOnlyCollection<EventEnvelope>> AppendRawAsync(
+        string streamName,
+        string streamId,
+        long expectedVersion,
+        IReadOnlyCollection<RawEventData> events,
+        CancellationToken cancellationToken = default)
+        => AppendRawAsync(streamName, streamId, ExpectedVersion.Exact(expectedVersion), events, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyCollection<EventEnvelope>> AppendRawAsync(
+        string streamName,
+        string streamId,
+        ExpectedVersion expectedVersion,
+        IReadOnlyCollection<RawEventData> events,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(streamName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(streamId);
+        ArgumentNullException.ThrowIfNull(events);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_syncRoot)
+        {
+            var key = new StreamKey(streamName, streamId);
+
+            if (!_streams.TryGetValue(key, out var stream))
+            {
+                stream = [];
+                _streams[key] = stream;
+            }
+
+            var actualVersion = stream.Count == 0 ? 0 : stream[^1].StreamVersion;
+
+            EnsureExpectedVersion(streamName, streamId, expectedVersion, actualVersion);
+
+            return AppendRawCoreAsync(streamName, streamId, stream, actualVersion, events);
+        }
+    }
+
+    /// <inheritdoc />
     public Task<IReadOnlyCollection<EventEnvelope>> ReadFromAsync(
         string streamName,
         long afterGlobalPosition,
@@ -197,6 +238,27 @@ public sealed class InMemoryEventStore : IEventStore, IEventLogReader
             cancellationToken);
 
         return envelopes;
+    }
+
+    private Task<IReadOnlyCollection<EventEnvelope>> AppendRawCoreAsync(
+        string streamName,
+        string streamId,
+        List<EventEnvelope> stream,
+        long expectedVersion,
+        IReadOnlyCollection<RawEventData> events)
+    {
+        var envelopes = _envelopeFactory.CreateRaw(
+                streamName,
+                streamId,
+                streamType: null,
+                expectedVersion,
+                events)
+            .Select(envelope => envelope with { GlobalPosition = ++_globalPosition })
+            .ToArray();
+
+        stream.AddRange(envelopes);
+
+        return Task.FromResult<IReadOnlyCollection<EventEnvelope>>(envelopes);
     }
 
     private sealed class NoOpSnapshotCandidateMarker : ISnapshotCandidateMarker

--- a/tests/Krackend.EventSourcing.Tests/EntityFrameworkEventStoreTests.cs
+++ b/tests/Krackend.EventSourcing.Tests/EntityFrameworkEventStoreTests.cs
@@ -42,6 +42,37 @@ public sealed class EntityFrameworkEventStoreTests
     }
 
     [Fact]
+    public async Task AppendRawAsync_persists_untyped_events_in_app_db_context_event_store()
+    {
+        using var provider = BuildProvider();
+        using var scope = provider.CreateScope();
+        var rawEventStore = scope.ServiceProvider.GetRequiredService<IRawEventStore>();
+
+        await rawEventStore.AppendRawAsync(
+            "payments",
+            "payment-1",
+            ExpectedVersion.NoStream,
+            [
+                new RawEventData(
+                    "Billing.PaymentCaptured",
+                    new SemanticVersion(2, 0, 0),
+                    "{\"paymentId\":\"payment-1\",\"amount\":250.00}",
+                    "{\"sourceSystem\":\"billing\"}")
+            ]);
+
+        var envelopes = await rawEventStore.ReadStreamAsync("payments", "payment-1", fromVersion: 1, maxCount: 10);
+        var dbContext = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+        var record = await dbContext.Set<EventStoreRecord>("payments").SingleAsync();
+
+        var envelope = Assert.Single(envelopes);
+        Assert.Equal("Billing.PaymentCaptured", envelope.EventType);
+        Assert.Equal(new SemanticVersion(2, 0, 0), envelope.EventSchemaVersion);
+        Assert.Equal("{\"paymentId\":\"payment-1\",\"amount\":250.00}", envelope.Payload);
+        Assert.Equal("{\"sourceSystem\":\"billing\"}", record.Metadata);
+        Assert.Equal("2.0.0", record.EventSchemaVersion);
+    }
+
+    [Fact]
     public async Task AppendAsync_with_any_expected_version_appends_and_updates_current_version()
     {
         using var provider = BuildProvider();

--- a/tests/Krackend.EventSourcing.Tests/InMemoryEventStoreTests.cs
+++ b/tests/Krackend.EventSourcing.Tests/InMemoryEventStoreTests.cs
@@ -1,4 +1,5 @@
 using Krackend.EventSourcing.Configuration;
+using Krackend.EventSourcing.Contracts;
 using Krackend.EventSourcing.Envelopes;
 using Krackend.EventSourcing.Metadata;
 using Krackend.EventSourcing.Registry;
@@ -122,6 +123,78 @@ public sealed class InMemoryEventStoreTests
 
         Assert.Equal(0, exception.ExpectedVersion);
         Assert.Equal(1, exception.ActualVersion);
+    }
+
+    [Fact]
+    public async Task AppendRawAsync_stores_untyped_event_without_event_registration()
+    {
+        var store = CreateStore();
+
+        var envelopes = await store.AppendRawAsync(
+            "integration-events",
+            "billing:payment-001",
+            ExpectedVersion.NoStream,
+            [
+                new RawEventData(
+                    "Billing.PaymentCaptured",
+                    new SemanticVersion(2, 1, 0),
+                    "{\"paymentId\":\"payment-001\",\"amount\":150.25}",
+                    "{\"sourceSystem\":\"billing\"}")
+            ]);
+
+        var envelope = Assert.Single(envelopes);
+        Assert.Equal("Billing.PaymentCaptured", envelope.EventType);
+        Assert.Equal(new SemanticVersion(2, 1, 0), envelope.EventSchemaVersion);
+        Assert.Equal(1, envelope.StreamVersion);
+        Assert.Equal(1, envelope.GlobalPosition);
+        Assert.Equal("{\"paymentId\":\"payment-001\",\"amount\":150.25}", envelope.Payload);
+        Assert.Equal("{\"sourceSystem\":\"billing\"}", envelope.Metadata);
+    }
+
+    [Fact]
+    public async Task AppendRawAsync_respects_expected_version()
+    {
+        var store = CreateStore();
+
+        await store.AppendRawAsync(
+            "integration-events",
+            "customer:customer-001",
+            ExpectedVersion.NoStream,
+            [new RawEventData("Customers.CustomerCreated", SemanticVersion.Default, "{\"customerId\":\"customer-001\"}")]);
+
+        var exception = await Assert.ThrowsAsync<EventStoreConcurrencyException>(() =>
+            store.AppendRawAsync(
+                "integration-events",
+                "customer:customer-001",
+                ExpectedVersion.NoStream,
+                [new RawEventData("Customers.CustomerRenamed", SemanticVersion.Default, "{\"customerId\":\"customer-001\"}")]));
+
+        Assert.Equal(0, exception.ExpectedVersion);
+        Assert.Equal(1, exception.ActualVersion);
+    }
+
+    [Fact]
+    public async Task AppendRawAsync_can_append_after_typed_events_in_the_same_stream()
+    {
+        var store = CreateStore();
+
+        await store.AppendAsync("orders", "order-1", ExpectedVersion.NoStream, [new OrderCreated("order-1")]);
+        await store.AppendRawAsync(
+            "orders",
+            "order-1",
+            ExpectedVersion.Exact(1),
+            [new RawEventData("External.OrderSynced", SemanticVersion.Default, "{\"orderId\":\"order-1\"}")]);
+
+        var envelopes = await store.ReadStreamAsync("orders", "order-1", fromVersion: 1, maxCount: 10);
+
+        Assert.Collection(
+            envelopes,
+            first => Assert.Equal("OrderCreated", first.EventType),
+            second =>
+            {
+                Assert.Equal("External.OrderSynced", second.EventType);
+                Assert.Equal(2, second.StreamVersion);
+            });
     }
 
     private static InMemoryEventStore CreateStore(


### PR DESCRIPTION
## Summary

Adds an additive raw event store path for centralized event logs that receive events from multiple bounded contexts without requiring CLR event classes for every event type and schema version.

## Changes

- Added `IRawEventStore` and `RawEventData` contracts.
- Added raw envelope creation while preserving stream version, global position, correlation, causation, tenant, user, source, payload, and metadata.
- Implemented raw appends in the in-memory and EF Core event stores.
- Registered `IRawEventStore` in core and EF dependency injection.
- Added tests for raw append, expected version handling, metadata preservation, EF persistence, and coexistence with typed events.
- Added a centralized SQLite sample under `samples/Krackend.EventSourcing.Centralized.Sample`.
- Updated README, changelog, and Event Sourcing docs.

## Validation

- `dotnet test tests\Krackend.EventSourcing.Tests\Krackend.EventSourcing.Tests.csproj --no-restore --configuration Release`
- `dotnet run --framework net9.0 --project samples\Krackend.EventSourcing.Centralized.Sample\Krackend.EventSourcing.Centralized.Sample.csproj`
- `dotnet build --configuration Release`

## Notes

The typed event sourcing API remains unchanged. The raw API is additive and intended for centralized storage, audit, forwarding, and integration collection scenarios.