### PR TITLE
Add Krackend testing package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,7 @@ jobs:
             "src/Krackend.EventSourcing.EntityFrameworkCore/Krackend.EventSourcing.EntityFrameworkCore.csproj"
             "src/Krackend.EventSourcing.Analyzers/Krackend.EventSourcing.Analyzers.csproj"
             "src/Krackend.EventSourcing.Testing/Krackend.EventSourcing.Testing.csproj"
+            "src/Krackend.Testing/Krackend.Testing.csproj"
           )
 
           for project in "${projects[@]}"; do
@@ -116,9 +117,6 @@ jobs:
         run: |
           TAG="${{ steps.version.outputs.tag }}"
           HEAD_SHA="$(git rev-parse HEAD)"
-
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
 
           if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
             git fetch --force origin "refs/tags/$TAG:refs/tags/$TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+------
+
+## [v1.2.0] - 2026-08-07
+
 - ### Added
 
   - Added `Krackend.Testing` with an in-memory test event store, adapter-friendly registration, event assertions, metadata and payload assertions, expected-version behavior, and concurrency failure simulation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ### Added
+
+  - Added `Krackend.Testing` with an in-memory test event store, adapter-friendly registration, event assertions, metadata and payload assertions, expected-version behavior, and concurrency failure simulation.
+
 ------
 
 ## [v1.1.0] - 2026-08-06

--- a/Krackend.sln
+++ b/Krackend.sln
@@ -41,6 +41,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Krackend.EventSourcing.Test
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Krackend.EventSourcing.Centralized.Sample", "samples\Krackend.EventSourcing.Centralized.Sample\Krackend.EventSourcing.Centralized.Sample.csproj", "{CB23D773-B534-467C-9A71-983CD3759FB9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Krackend.Testing", "src\Krackend.Testing\Krackend.Testing.csproj", "{A1A8CA07-48DA-4227-B429-6C854389F616}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Krackend.Testing.Tests", "tests\Krackend.Testing.Tests\Krackend.Testing.Tests.csproj", "{9D5112C0-0EAD-4C46-919F-329ADFDA11E0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -207,6 +211,30 @@ Global
 		{CB23D773-B534-467C-9A71-983CD3759FB9}.Release|x64.Build.0 = Release|Any CPU
 		{CB23D773-B534-467C-9A71-983CD3759FB9}.Release|x86.ActiveCfg = Release|Any CPU
 		{CB23D773-B534-467C-9A71-983CD3759FB9}.Release|x86.Build.0 = Release|Any CPU
+		{A1A8CA07-48DA-4227-B429-6C854389F616}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1A8CA07-48DA-4227-B429-6C854389F616}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1A8CA07-48DA-4227-B429-6C854389F616}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A1A8CA07-48DA-4227-B429-6C854389F616}.Debug|x64.Build.0 = Debug|Any CPU
+		{A1A8CA07-48DA-4227-B429-6C854389F616}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A1A8CA07-48DA-4227-B429-6C854389F616}.Debug|x86.Build.0 = Debug|Any CPU
+		{A1A8CA07-48DA-4227-B429-6C854389F616}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1A8CA07-48DA-4227-B429-6C854389F616}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1A8CA07-48DA-4227-B429-6C854389F616}.Release|x64.ActiveCfg = Release|Any CPU
+		{A1A8CA07-48DA-4227-B429-6C854389F616}.Release|x64.Build.0 = Release|Any CPU
+		{A1A8CA07-48DA-4227-B429-6C854389F616}.Release|x86.ActiveCfg = Release|Any CPU
+		{A1A8CA07-48DA-4227-B429-6C854389F616}.Release|x86.Build.0 = Release|Any CPU
+		{9D5112C0-0EAD-4C46-919F-329ADFDA11E0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9D5112C0-0EAD-4C46-919F-329ADFDA11E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9D5112C0-0EAD-4C46-919F-329ADFDA11E0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9D5112C0-0EAD-4C46-919F-329ADFDA11E0}.Debug|x64.Build.0 = Debug|Any CPU
+		{9D5112C0-0EAD-4C46-919F-329ADFDA11E0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9D5112C0-0EAD-4C46-919F-329ADFDA11E0}.Debug|x86.Build.0 = Debug|Any CPU
+		{9D5112C0-0EAD-4C46-919F-329ADFDA11E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9D5112C0-0EAD-4C46-919F-329ADFDA11E0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9D5112C0-0EAD-4C46-919F-329ADFDA11E0}.Release|x64.ActiveCfg = Release|Any CPU
+		{9D5112C0-0EAD-4C46-919F-329ADFDA11E0}.Release|x64.Build.0 = Release|Any CPU
+		{9D5112C0-0EAD-4C46-919F-329ADFDA11E0}.Release|x86.ActiveCfg = Release|Any CPU
+		{9D5112C0-0EAD-4C46-919F-329ADFDA11E0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -225,6 +253,8 @@ Global
 		{6AB71B0E-2DCE-4C96-A0A5-FE1B7BE72717} = {6711B2C7-0746-4A45-8E61-BA235480C06A}
 		{363783F6-B512-4228-A413-F81027349471} = {6711B2C7-0746-4A45-8E61-BA235480C06A}
 		{CB23D773-B534-467C-9A71-983CD3759FB9} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
+		{A1A8CA07-48DA-4227-B429-6C854389F616} = {6711B2C7-0746-4A45-8E61-BA235480C06A}
+		{9D5112C0-0EAD-4C46-919F-329ADFDA11E0} = {E888E2D4-A105-4B19-8A53-86DFDA724740}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3F2B5274-3B0F-4F73-B211-9BD128E1AF56}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ dotnet add package Krackend.EventSourcing
 dotnet add package Krackend.EventSourcing.EntityFrameworkCore
 dotnet add package Krackend.EventSourcing.Analyzers
 dotnet add package Krackend.EventSourcing.Testing
+dotnet add package Krackend.Testing
 ```
 
 Optional event sourcing packages:
@@ -88,3 +89,25 @@ Samples:
 - `samples/Krackend.EventSourcing.Sqlite.Sample`: typed event-sourced write model with SQLite.
 - `samples/Krackend.EventSourcing.Centralized.Sample`: centralized raw JSON event store with SQLite.
 - `samples/Krackend.EventSourcing.Pelican.Sample`: exploratory Pelican/template integration.
+
+## Testing
+
+`Krackend.Testing` provides an in-memory event store for testing event flow behavior without a real event store:
+
+```csharp
+services.AddKrackendTesting();
+
+var eventStore = provider.GetRequiredService<IKrackendTestEventStore>();
+var stream = EventStreamReference.Create("customers", customerId);
+
+await eventStore.AppendAsync(stream, [new CustomerCreated(customerId)]);
+
+eventStore.ShouldHaveEvent<CustomerCreated>("customers", customerId);
+eventStore.ShouldHaveVersion("customers", customerId, 1);
+```
+
+External test host integrations can use:
+
+```csharp
+services.AddKrackendTestingAdapter();
+```

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Samples:
 
 ## Testing
 
-`Krackend.Testing` provides an in-memory event store for testing event flow behavior without a real event store:
+`Krackend.Testing` provides an in-memory event store for testing event flow behavior without a real event store. It is meant for application tests, package adapters, and external test hosts that need to assert event sourcing behavior without booting EF Core, SQL Server, SQLite, or a production event store.
 
 ```csharp
 services.AddKrackendTesting();
@@ -106,8 +106,42 @@ eventStore.ShouldHaveEvent<CustomerCreated>("customers", customerId);
 eventStore.ShouldHaveVersion("customers", customerId, 1);
 ```
 
+Append with expected-version behavior and metadata:
+
+```csharp
+await eventStore.AppendAsync(
+    stream,
+    ExpectedVersion.NoStream,
+    [new CustomerCreated(customerId)],
+    new Dictionary<string, object?>
+    {
+        ["correlation-id"] = correlationId
+    });
+```
+
+Available assertions include:
+
+- stream existence
+- event type
+- event order
+- stream version
+- metadata
+- serialized payload
+
+Failure simulation:
+
+```csharp
+eventStore.FailNextAppendWithConcurrencyConflict(stream);
+```
+
 External test host integrations can use:
 
 ```csharp
 services.AddKrackendTestingAdapter();
+```
+
+That adapter-friendly registration allows wrappers such as:
+
+```csharp
+testHost.UseKrackendTesting();
 ```

--- a/src/Krackend.Testing/IKrackendTestEventStore.cs
+++ b/src/Krackend.Testing/IKrackendTestEventStore.cs
@@ -1,0 +1,64 @@
+using Krackend.EventSourcing.Stores;
+using Krackend.EventSourcing.Streams;
+
+namespace Krackend.Testing;
+
+/// <summary>
+/// Provides an in-memory event store for testing event sourcing flows without a real event store.
+/// </summary>
+public interface IKrackendTestEventStore
+{
+    /// <summary>
+    /// Appends events to a stream without an optimistic concurrency precondition.
+    /// </summary>
+    Task<IReadOnlyCollection<TestEventEnvelope>> AppendAsync(
+        EventStreamReference stream,
+        IReadOnlyCollection<object> events,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Appends events to a stream with metadata and without an optimistic concurrency precondition.
+    /// </summary>
+    Task<IReadOnlyCollection<TestEventEnvelope>> AppendAsync(
+        EventStreamReference stream,
+        IReadOnlyCollection<object> events,
+        IReadOnlyDictionary<string, object?> metadata,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Appends events to a stream using the specified optimistic concurrency precondition.
+    /// </summary>
+    Task<IReadOnlyCollection<TestEventEnvelope>> AppendAsync(
+        EventStreamReference stream,
+        ExpectedVersion expectedVersion,
+        IReadOnlyCollection<object> events,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Appends events to a stream using the specified optimistic concurrency precondition and metadata.
+    /// </summary>
+    Task<IReadOnlyCollection<TestEventEnvelope>> AppendAsync(
+        EventStreamReference stream,
+        ExpectedVersion expectedVersion,
+        IReadOnlyCollection<object> events,
+        IReadOnlyDictionary<string, object?> metadata,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads events from a stream in stream-version order.
+    /// </summary>
+    Task<IReadOnlyCollection<TestEventEnvelope>> ReadAsync(
+        EventStreamReference stream,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads all events in append order.
+    /// </summary>
+    Task<IReadOnlyCollection<TestEventEnvelope>> ReadAllAsync(
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Makes the next append to the specified stream fail with an optimistic concurrency conflict.
+    /// </summary>
+    void FailNextAppendWithConcurrencyConflict(EventStreamReference stream);
+}

--- a/src/Krackend.Testing/IKrackendTestingAdapter.cs
+++ b/src/Krackend.Testing/IKrackendTestingAdapter.cs
@@ -1,0 +1,12 @@
+namespace Krackend.Testing;
+
+/// <summary>
+/// Exposes Krackend testing services to external test host integrations.
+/// </summary>
+public interface IKrackendTestingAdapter
+{
+    /// <summary>
+    /// Gets the in-memory test event store.
+    /// </summary>
+    IKrackendTestEventStore EventStore { get; }
+}

--- a/src/Krackend.Testing/InMemoryKrackendTestEventStore.cs
+++ b/src/Krackend.Testing/InMemoryKrackendTestEventStore.cs
@@ -1,0 +1,167 @@
+using System.Text.Json;
+using Krackend.EventSourcing.Stores;
+using Krackend.EventSourcing.Streams;
+
+namespace Krackend.Testing;
+
+/// <summary>
+/// In-memory implementation of <see cref="IKrackendTestEventStore"/>.
+/// </summary>
+public sealed class InMemoryKrackendTestEventStore : IKrackendTestEventStore
+{
+    private readonly object _syncRoot = new();
+    private readonly Dictionary<EventStreamReference, List<TestEventEnvelope>> _streams = [];
+    private readonly HashSet<EventStreamReference> _failedAppends = [];
+    private long _globalPosition;
+
+    /// <inheritdoc />
+    public Task<IReadOnlyCollection<TestEventEnvelope>> AppendAsync(
+        EventStreamReference stream,
+        IReadOnlyCollection<object> events,
+        CancellationToken cancellationToken = default)
+        => AppendAsync(stream, ExpectedVersion.Any, events, EmptyMetadata(), cancellationToken);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyCollection<TestEventEnvelope>> AppendAsync(
+        EventStreamReference stream,
+        IReadOnlyCollection<object> events,
+        IReadOnlyDictionary<string, object?> metadata,
+        CancellationToken cancellationToken = default)
+        => AppendAsync(stream, ExpectedVersion.Any, events, metadata, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyCollection<TestEventEnvelope>> AppendAsync(
+        EventStreamReference stream,
+        ExpectedVersion expectedVersion,
+        IReadOnlyCollection<object> events,
+        CancellationToken cancellationToken = default)
+        => AppendAsync(stream, expectedVersion, events, EmptyMetadata(), cancellationToken);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyCollection<TestEventEnvelope>> AppendAsync(
+        EventStreamReference stream,
+        ExpectedVersion expectedVersion,
+        IReadOnlyCollection<object> events,
+        IReadOnlyDictionary<string, object?> metadata,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateStream(stream);
+        ArgumentNullException.ThrowIfNull(events);
+        ArgumentNullException.ThrowIfNull(metadata);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_syncRoot)
+        {
+            if (!_streams.TryGetValue(stream, out var storedEvents))
+            {
+                storedEvents = [];
+                _streams[stream] = storedEvents;
+            }
+
+            var actualVersion = storedEvents.Count == 0 ? 0 : storedEvents[^1].StreamVersion;
+
+            if (_failedAppends.Remove(stream))
+                throw new EventStoreConcurrencyException(stream.Name, stream.Id, actualVersion, actualVersion + 1);
+
+            EnsureExpectedVersion(stream, expectedVersion, actualVersion);
+
+            var appended = new List<TestEventEnvelope>(events.Count);
+            var version = actualVersion;
+            var occurredAt = DateTimeOffset.UtcNow;
+            var eventMetadata = new Dictionary<string, object?>(metadata, StringComparer.Ordinal);
+
+            foreach (var @event in events)
+            {
+                ArgumentNullException.ThrowIfNull(@event);
+
+                version++;
+                _globalPosition++;
+
+                var envelope = new TestEventEnvelope(
+                    EventId: Guid.NewGuid(),
+                    Stream: stream,
+                    StreamVersion: version,
+                    GlobalPosition: _globalPosition,
+                    EventType: @event.GetType().Name,
+                    EventClrType: @event.GetType(),
+                    Event: @event,
+                    SerializedPayload: JsonSerializer.Serialize(@event, @event.GetType()),
+                    Metadata: eventMetadata,
+                    OccurredAt: occurredAt);
+
+                storedEvents.Add(envelope);
+                appended.Add(envelope);
+            }
+
+            return Task.FromResult<IReadOnlyCollection<TestEventEnvelope>>(appended);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyCollection<TestEventEnvelope>> ReadAsync(
+        EventStreamReference stream,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateStream(stream);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_syncRoot)
+        {
+            return Task.FromResult<IReadOnlyCollection<TestEventEnvelope>>(
+                _streams.TryGetValue(stream, out var events)
+                    ? events.OrderBy(x => x.StreamVersion).ToArray()
+                    : []);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyCollection<TestEventEnvelope>> ReadAllAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_syncRoot)
+        {
+            return Task.FromResult<IReadOnlyCollection<TestEventEnvelope>>(
+                _streams
+                    .SelectMany(x => x.Value)
+                    .OrderBy(x => x.GlobalPosition)
+                    .ToArray());
+        }
+    }
+
+    /// <inheritdoc />
+    public void FailNextAppendWithConcurrencyConflict(EventStreamReference stream)
+    {
+        ValidateStream(stream);
+
+        lock (_syncRoot)
+        {
+            _failedAppends.Add(stream);
+        }
+    }
+
+    private static IReadOnlyDictionary<string, object?> EmptyMetadata()
+        => new Dictionary<string, object?>(StringComparer.Ordinal);
+
+    private static void EnsureExpectedVersion(
+        EventStreamReference stream,
+        ExpectedVersion expectedVersion,
+        long actualVersion)
+    {
+        if (expectedVersion.Mode == ExpectedVersionMode.Any)
+            return;
+
+        var expected = expectedVersion.Mode == ExpectedVersionMode.NoStream
+            ? 0
+            : expectedVersion.Value;
+
+        if (actualVersion != expected)
+            throw new EventStoreConcurrencyException(stream.Name, stream.Id, expected, actualVersion);
+    }
+
+    private static void ValidateStream(EventStreamReference stream)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stream.Name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(stream.Id);
+    }
+}

--- a/src/Krackend.Testing/Krackend.Testing.csproj
+++ b/src/Krackend.Testing/Krackend.Testing.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageId>Krackend.Testing</PackageId>
+    <Description>Krackend.Testing provides in-memory event flow testing utilities for Krackend applications and external test hosts.</Description>
+    <PackageTags>testing;event-sourcing;event-store;dotnet</PackageTags>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <UseRootPackageReadme>false</UseRootPackageReadme>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="README.md" />
+    <None Include="..\..\assets\image.png" Pack="true" Visible="false" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Krackend.EventSourcing.Abstractions\Krackend.EventSourcing.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+</Project>

--- a/src/Krackend.Testing/KrackendTestEventStoreAssertions.cs
+++ b/src/Krackend.Testing/KrackendTestEventStoreAssertions.cs
@@ -1,0 +1,161 @@
+using System.Text.Json;
+using Krackend.EventSourcing.Streams;
+
+namespace Krackend.Testing;
+
+/// <summary>
+/// Provides assertion helpers for <see cref="IKrackendTestEventStore"/>.
+/// </summary>
+public static class KrackendTestEventStoreAssertions
+{
+    /// <summary>
+    /// Asserts that the specified stream exists.
+    /// </summary>
+    public static IKrackendTestEventStore ShouldHaveStream(
+        this IKrackendTestEventStore eventStore,
+        string streamName,
+        string streamId)
+    {
+        var stream = EventStreamReference.Create(streamName, streamId);
+        var events = ReadStream(eventStore, stream);
+
+        if (events.Count == 0)
+            throw new KrackendTestingAssertionException($"Expected stream '{stream.Name}/{stream.Id}' to exist.");
+
+        return eventStore;
+    }
+
+    /// <summary>
+    /// Asserts that the specified stream contains an event of the requested CLR type.
+    /// </summary>
+    public static IKrackendTestEventStore ShouldHaveEvent<TEvent>(
+        this IKrackendTestEventStore eventStore,
+        string streamName,
+        string streamId)
+    {
+        var stream = EventStreamReference.Create(streamName, streamId);
+        var events = ReadStream(eventStore, stream);
+
+        if (!events.Any(x => x.EventClrType == typeof(TEvent)))
+            throw new KrackendTestingAssertionException($"Expected stream '{stream.Name}/{stream.Id}' to contain event '{typeof(TEvent).Name}'.");
+
+        return eventStore;
+    }
+
+    /// <summary>
+    /// Asserts that the specified stream contains exactly the requested event types in order.
+    /// </summary>
+    public static IKrackendTestEventStore ShouldHaveEventsInOrder(
+        this IKrackendTestEventStore eventStore,
+        string streamName,
+        string streamId,
+        params Type[] eventTypes)
+    {
+        ArgumentNullException.ThrowIfNull(eventTypes);
+
+        var stream = EventStreamReference.Create(streamName, streamId);
+        var actual = ReadStream(eventStore, stream)
+            .Select(x => x.EventClrType)
+            .ToArray();
+
+        if (!actual.SequenceEqual(eventTypes))
+        {
+            var expectedNames = string.Join(", ", eventTypes.Select(x => x.Name));
+            var actualNames = string.Join(", ", actual.Select(x => x.Name));
+            throw new KrackendTestingAssertionException($"Expected stream '{stream.Name}/{stream.Id}' event order [{expectedNames}] but found [{actualNames}].");
+        }
+
+        return eventStore;
+    }
+
+    /// <summary>
+    /// Asserts that the specified stream has the expected version.
+    /// </summary>
+    public static IKrackendTestEventStore ShouldHaveVersion(
+        this IKrackendTestEventStore eventStore,
+        string streamName,
+        string streamId,
+        long expectedVersion)
+    {
+        var stream = EventStreamReference.Create(streamName, streamId);
+        var actualVersion = ReadStream(eventStore, stream)
+            .Select(x => x.StreamVersion)
+            .DefaultIfEmpty(0)
+            .Max();
+
+        if (actualVersion != expectedVersion)
+            throw new KrackendTestingAssertionException($"Expected stream '{stream.Name}/{stream.Id}' version '{expectedVersion}' but found '{actualVersion}'.");
+
+        return eventStore;
+    }
+
+    /// <summary>
+    /// Asserts that any stored event has metadata matching the specified key and value.
+    /// </summary>
+    public static IKrackendTestEventStore ShouldHaveMetadata(
+        this IKrackendTestEventStore eventStore,
+        string key,
+        object? value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        var events = ReadAll(eventStore);
+
+        if (!events.Any(x => x.Metadata.TryGetValue(key, out var actual) && ValuesEqual(actual, value)))
+            throw new KrackendTestingAssertionException($"Expected metadata '{key}' with value '{value}' to exist.");
+
+        return eventStore;
+    }
+
+    /// <summary>
+    /// Asserts that the specified stream contains a serialized payload matching the provided JSON.
+    /// </summary>
+    public static IKrackendTestEventStore ShouldHaveSerializedPayload(
+        this IKrackendTestEventStore eventStore,
+        string streamName,
+        string streamId,
+        string expectedJson)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(expectedJson);
+
+        var stream = EventStreamReference.Create(streamName, streamId);
+        var expected = NormalizeJson(expectedJson);
+        var found = ReadStream(eventStore, stream)
+            .Any(x => NormalizeJson(x.SerializedPayload) == expected);
+
+        if (!found)
+            throw new KrackendTestingAssertionException($"Expected stream '{stream.Name}/{stream.Id}' to contain serialized payload '{expected}'.");
+
+        return eventStore;
+    }
+
+    private static IReadOnlyCollection<TestEventEnvelope> ReadStream(
+        IKrackendTestEventStore eventStore,
+        EventStreamReference stream)
+    {
+        ArgumentNullException.ThrowIfNull(eventStore);
+        return eventStore.ReadAsync(stream).GetAwaiter().GetResult();
+    }
+
+    private static IReadOnlyCollection<TestEventEnvelope> ReadAll(IKrackendTestEventStore eventStore)
+    {
+        ArgumentNullException.ThrowIfNull(eventStore);
+        return eventStore.ReadAllAsync().GetAwaiter().GetResult();
+    }
+
+    private static string NormalizeJson(string source)
+        => JsonSerializer.Serialize(JsonSerializer.Deserialize<JsonElement>(source));
+
+    private static bool ValuesEqual(object? actual, object? expected)
+        => actual switch
+        {
+            null => expected is null,
+            JsonElement jsonElement => JsonElementEquals(jsonElement, expected),
+            _ => actual.Equals(expected)
+        };
+
+    private static bool JsonElementEquals(JsonElement actual, object? expected)
+        => expected is JsonElement expectedJson
+            ? JsonSerializer.Serialize(actual) == JsonSerializer.Serialize(expectedJson)
+            : actual.ToString() == expected?.ToString();
+}

--- a/src/Krackend.Testing/KrackendTestingAdapter.cs
+++ b/src/Krackend.Testing/KrackendTestingAdapter.cs
@@ -1,0 +1,18 @@
+namespace Krackend.Testing;
+
+/// <summary>
+/// Default implementation of <see cref="IKrackendTestingAdapter"/>.
+/// </summary>
+public sealed class KrackendTestingAdapter : IKrackendTestingAdapter
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KrackendTestingAdapter"/> class.
+    /// </summary>
+    public KrackendTestingAdapter(IKrackendTestEventStore eventStore)
+    {
+        EventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
+    }
+
+    /// <inheritdoc />
+    public IKrackendTestEventStore EventStore { get; }
+}

--- a/src/Krackend.Testing/KrackendTestingAssertionException.cs
+++ b/src/Krackend.Testing/KrackendTestingAssertionException.cs
@@ -1,0 +1,15 @@
+namespace Krackend.Testing;
+
+/// <summary>
+/// Represents a failed Krackend testing assertion.
+/// </summary>
+public sealed class KrackendTestingAssertionException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KrackendTestingAssertionException"/> class.
+    /// </summary>
+    public KrackendTestingAssertionException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/Krackend.Testing/KrackendTestingServiceCollectionExtensions.cs
+++ b/src/Krackend.Testing/KrackendTestingServiceCollectionExtensions.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Krackend.Testing;
+
+/// <summary>
+/// Provides dependency injection helpers for Krackend testing.
+/// </summary>
+public static class KrackendTestingServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the in-memory Krackend test event store.
+    /// </summary>
+    public static IServiceCollection AddKrackendTesting(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton<IKrackendTestEventStore, InMemoryKrackendTestEventStore>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers Krackend testing services in an adapter-friendly shape for external test hosts.
+    /// </summary>
+    public static IServiceCollection AddKrackendTestingAdapter(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddKrackendTesting();
+        services.TryAddSingleton<IKrackendTestingAdapter, KrackendTestingAdapter>();
+
+        return services;
+    }
+}

--- a/src/Krackend.Testing/README.md
+++ b/src/Krackend.Testing/README.md
@@ -1,0 +1,35 @@
+# Krackend.Testing
+
+`Krackend.Testing` provides an in-memory event store for testing event sourcing flows without a real event store.
+
+## Setup
+
+```csharp
+services.AddKrackendTesting();
+```
+
+Adapter-friendly registration for external test hosts:
+
+```csharp
+services.AddKrackendTestingAdapter();
+```
+
+## Usage
+
+```csharp
+var eventStore = provider.GetRequiredService<IKrackendTestEventStore>();
+var stream = EventStreamReference.Create("customers", customerId);
+
+await eventStore.AppendAsync(stream, [new CustomerCreated(customerId)]);
+
+var events = await eventStore.ReadAsync(stream);
+
+eventStore.ShouldHaveEvent<CustomerCreated>("customers", customerId);
+eventStore.ShouldHaveVersion("customers", customerId, 1);
+```
+
+## Failure Simulation
+
+```csharp
+eventStore.FailNextAppendWithConcurrencyConflict(stream);
+```

--- a/src/Krackend.Testing/README.md
+++ b/src/Krackend.Testing/README.md
@@ -28,8 +28,38 @@ eventStore.ShouldHaveEvent<CustomerCreated>("customers", customerId);
 eventStore.ShouldHaveVersion("customers", customerId, 1);
 ```
 
+Append with expected-version behavior and metadata:
+
+```csharp
+await eventStore.AppendAsync(
+    stream,
+    ExpectedVersion.NoStream,
+    [new CustomerCreated(customerId)],
+    new Dictionary<string, object?>
+    {
+        ["correlation-id"] = correlationId
+    });
+```
+
+Assertions:
+
+```csharp
+eventStore.ShouldHaveStream("customers", customerId);
+eventStore.ShouldHaveEvent<CustomerCreated>("customers", customerId);
+eventStore.ShouldHaveEventsInOrder("customers", customerId, typeof(CustomerCreated), typeof(CustomerRenamed));
+eventStore.ShouldHaveVersion("customers", customerId, 2);
+eventStore.ShouldHaveMetadata("correlation-id", correlationId);
+eventStore.ShouldHaveSerializedPayload("customers", customerId, """{"CustomerId":"customer-001"}""");
+```
+
 ## Failure Simulation
 
 ```csharp
 eventStore.FailNextAppendWithConcurrencyConflict(stream);
+```
+
+External test hosts can wrap `AddKrackendTestingAdapter()` with a host-specific extension:
+
+```csharp
+testHost.UseKrackendTesting();
 ```

--- a/src/Krackend.Testing/TestEventEnvelope.cs
+++ b/src/Krackend.Testing/TestEventEnvelope.cs
@@ -1,0 +1,18 @@
+using Krackend.EventSourcing.Streams;
+
+namespace Krackend.Testing;
+
+/// <summary>
+/// Represents one event captured by the in-memory test event store.
+/// </summary>
+public sealed record TestEventEnvelope(
+    Guid EventId,
+    EventStreamReference Stream,
+    long StreamVersion,
+    long GlobalPosition,
+    string EventType,
+    Type EventClrType,
+    object Event,
+    string SerializedPayload,
+    IReadOnlyDictionary<string, object?> Metadata,
+    DateTimeOffset OccurredAt);

--- a/tests/Krackend.Testing.Tests/InMemoryKrackendTestEventStoreTests.cs
+++ b/tests/Krackend.Testing.Tests/InMemoryKrackendTestEventStoreTests.cs
@@ -1,0 +1,136 @@
+using Krackend.EventSourcing.Stores;
+using Krackend.EventSourcing.Streams;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Krackend.Testing.Tests;
+
+public sealed class InMemoryKrackendTestEventStoreTests
+{
+    [Fact]
+    public async Task AddKrackendTesting_registers_in_memory_event_store()
+    {
+        var services = new ServiceCollection();
+
+        services.AddKrackendTesting();
+
+        using var provider = services.BuildServiceProvider();
+        var eventStore = provider.GetRequiredService<IKrackendTestEventStore>();
+
+        var stream = EventStreamReference.Create("customers", "customer-001");
+        await eventStore.AppendAsync(stream, [new CustomerCreated("customer-001")]);
+
+        var events = await eventStore.ReadAsync(stream);
+
+        Assert.Single(events);
+        Assert.IsType<InMemoryKrackendTestEventStore>(eventStore);
+    }
+
+    [Fact]
+    public void AddKrackendTestingAdapter_registers_adapter_for_external_test_hosts()
+    {
+        var services = new ServiceCollection();
+
+        services.AddKrackendTestingAdapter();
+
+        using var provider = services.BuildServiceProvider();
+        var adapter = provider.GetRequiredService<IKrackendTestingAdapter>();
+        var eventStore = provider.GetRequiredService<IKrackendTestEventStore>();
+
+        Assert.Same(eventStore, adapter.EventStore);
+    }
+
+    [Fact]
+    public async Task AppendAsync_and_ReadAsync_keep_event_order_and_versions()
+    {
+        var eventStore = new InMemoryKrackendTestEventStore();
+        var stream = EventStreamReference.Create("customers", "customer-001");
+
+        await eventStore.AppendAsync(stream, [new CustomerCreated("customer-001")]);
+        await eventStore.AppendAsync(stream, [new CustomerRenamed("customer-001", "New Name")]);
+
+        var events = await eventStore.ReadAsync(stream);
+
+        Assert.Collection(
+            events,
+            first =>
+            {
+                Assert.Equal(1, first.StreamVersion);
+                Assert.Equal(typeof(CustomerCreated), first.EventClrType);
+            },
+            second =>
+            {
+                Assert.Equal(2, second.StreamVersion);
+                Assert.Equal(typeof(CustomerRenamed), second.EventClrType);
+            });
+    }
+
+    [Fact]
+    public async Task AppendAsync_enforces_expected_version()
+    {
+        var eventStore = new InMemoryKrackendTestEventStore();
+        var stream = EventStreamReference.Create("customers", "customer-001");
+
+        await eventStore.AppendAsync(stream, ExpectedVersion.NoStream, [new CustomerCreated("customer-001")]);
+
+        var exception = await Assert.ThrowsAsync<EventStoreConcurrencyException>(() =>
+            eventStore.AppendAsync(stream, ExpectedVersion.NoStream, [new CustomerRenamed("customer-001", "New Name")]));
+
+        Assert.Equal(0, exception.ExpectedVersion);
+        Assert.Equal(1, exception.ActualVersion);
+    }
+
+    [Fact]
+    public async Task FailNextAppendWithConcurrencyConflict_fails_only_next_append_for_stream()
+    {
+        var eventStore = new InMemoryKrackendTestEventStore();
+        var stream = EventStreamReference.Create("customers", "customer-001");
+
+        eventStore.FailNextAppendWithConcurrencyConflict(stream);
+
+        await Assert.ThrowsAsync<EventStoreConcurrencyException>(() =>
+            eventStore.AppendAsync(stream, [new CustomerCreated("customer-001")]));
+
+        await eventStore.AppendAsync(stream, [new CustomerCreated("customer-001")]);
+
+        eventStore.ShouldHaveVersion("customers", "customer-001", 1);
+    }
+
+    [Fact]
+    public async Task Assertions_validate_stream_event_order_version_metadata_and_payload()
+    {
+        var eventStore = new InMemoryKrackendTestEventStore();
+        var stream = EventStreamReference.Create("customers", "customer-001");
+
+        await eventStore.AppendAsync(
+            stream,
+            [
+                new CustomerCreated("customer-001"),
+                new CustomerRenamed("customer-001", "New Name")
+            ],
+            new Dictionary<string, object?>
+            {
+                ["correlation-id"] = "request-001"
+            });
+
+        eventStore
+            .ShouldHaveStream("customers", "customer-001")
+            .ShouldHaveEvent<CustomerCreated>("customers", "customer-001")
+            .ShouldHaveEventsInOrder("customers", "customer-001", typeof(CustomerCreated), typeof(CustomerRenamed))
+            .ShouldHaveVersion("customers", "customer-001", 2)
+            .ShouldHaveMetadata("correlation-id", "request-001")
+            .ShouldHaveSerializedPayload("customers", "customer-001", """{"CustomerId":"customer-001","Name":"New Name"}""");
+    }
+
+    [Fact]
+    public void Assertion_failures_throw_krackend_testing_assertion_exception()
+    {
+        var eventStore = new InMemoryKrackendTestEventStore();
+
+        Assert.Throws<KrackendTestingAssertionException>(() =>
+            eventStore.ShouldHaveEvent<CustomerCreated>("customers", "customer-001"));
+    }
+
+    private sealed record CustomerCreated(string CustomerId);
+
+    private sealed record CustomerRenamed(string CustomerId, string Name);
+}

--- a/tests/Krackend.Testing.Tests/Krackend.Testing.Tests.csproj
+++ b/tests/Krackend.Testing.Tests/Krackend.Testing.Tests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.7" />
+    <ProjectReference Include="..\..\src\Krackend.Testing\Krackend.Testing.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Adds the new `Krackend.Testing` package for testing event sourcing flows without a real event store.

## Changes

- Added `IKrackendTestEventStore` with in-memory append/read behavior.
- Added `AddKrackendTesting()` registration.
- Added `AddKrackendTestingAdapter()` and `IKrackendTestingAdapter` for external test host wrappers.
- Added assertions for stream existence, event type, event order, stream version, metadata, and serialized payload.
- Added optimistic concurrency behavior and `FailNextAppendWithConcurrencyConflict(stream)` failure simulation.
- Added `Krackend.Testing.Tests` coverage for the required testing package behavior.
- Updated README and package README with usage examples.
- Prepared `CHANGELOG.md` for `v1.2.0`.
- Updated `release.yml` to include `Krackend.Testing` in packaged projects and removed the hardcoded git user configuration from tag creation.

## Validation

- `dotnet build --configuration Release`
- `dotnet test tests\Krackend.Testing.Tests\Krackend.Testing.Tests.csproj --no-restore --configuration Release`

## Notes

The package does not depend on TurtlePath. The NuGet trusted publishing user remains resolved from the repository variable `NUGET_USER`; no default user is hardcoded in the workflow.