### PR TITLE
Prepare EventSourcing testing patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ------
 
+## [v1.2.1] - 2026-08-10
+
+- ### Fixed
+
+  - Corrected the event sourcing testing release surface to keep DI-friendly testing adapter APIs in `Krackend.EventSourcing.Testing` and avoid publishing a separate `Krackend.Testing` package.
+
+------
+
 ## [v1.2.0] - 2026-08-09
 
 - ### Added


### PR DESCRIPTION
## Summary

Prepares the `v1.2.1` patch release notes for the EventSourcing testing adapter correction.

## Changes

- Keeps the already released `v1.2.0` changelog section intact.
- Adds a separate `v1.2.1 - 2026-08-10` section.
- Documents the fix: DI-friendly testing adapter APIs belong in `Krackend.EventSourcing.Testing`, and a separate `Krackend.Testing` package should not be published for this event sourcing behavior.

## Validation

- Rebased branch on latest `origin/main`.
- Verified diff against `origin/main` is limited to `CHANGELOG.md`.